### PR TITLE
Split links to other languages into different lines.

### DIFF
--- a/index.de.html
+++ b/index.de.html
@@ -32,7 +32,19 @@
         <p class="meta">
             von <a href="http://www.twitter.com/rogerdudler">Roger Dudler</a>
             <br />dank an <a href="http://www.twitter.com/tfnico">@tfnico</a>, <a href="http://www.twitter.com/fhd">@fhd</a> und <a href="http://www.namics.com">Namics</a><br />
-            diese anleitung in <a href="index.html">english</a>, <a href="index.es.html">español</a>, <a href="index.fr.html">français</a>, <a href="index.it.html">italiano</a>, <a href="index.nl.html">nederlands</a>, <a href="index.pt_BR.html">português</a>, <a href="index.ru.html">русский</a>, <br/>
+            diese anleitung in 
+            <a href="index.html">english</a>,
+            <a href="index.es.html">español</a>, 
+            <a href="index.fr.html">français</a>, 
+            <a href="index.it.html">italiano</a>, 
+            <a href="index.nl.html">nederlands</a>, 
+            <a href="index.pt_BR.html">português</a>, 
+            <a href="index.ru.html">русский</a>, 
+            <br/>
+            <a href="index.ja.html">日本語</a>, 
+            <a href="index.zh.html">中文</a>, 
+            <a href="index.ko.html">한국어</a>
+            <br />
             <a href="index.ja.html">日本語</a>, <a href="index.zh.html">中文</a>, <a href="index.ko.html">한국어</a><br />
             feedback auf <a href="https://github.com/rogerdudler/git-guide/issues">github</a>
         </p>

--- a/index.es.html
+++ b/index.es.html
@@ -28,8 +28,19 @@
         <p class="meta">
             by <a href="http://www.twitter.com/rogerdudler">Roger Dudler</a> (translation by <a href="http://www.twitter.com/lfbarragan">@lfbarragan</a>)
             <br />créditos a <a href="http://www.twitter.com/tfnico">@tfnico</a>, <a href="http://www.twitter.com/fhd">@fhd</a> and <a href="http://www.namics.com">Namics</a><br />
-            esta guía en <a href="index.de.html">deutsch</a>, <a href="index.html">english</a>, <a href="index.fr.html">français</a>, <a href="index.it.html">italiano</a>, <a href="index.nl.html">nederlands</a>, <a href="index.pt_BR.html">português</a>, <a href="index.ru.html">русский</a>, <br/>
-            <a href="index.ja.html">日本語</a>, <a href="index.zh.html">中文</a>, <a href="index.ko.html">한국어</a><br />
+            esta guía en 
+            <a href="index.html">english</a>,
+            <a href="index.de.html">deutsch</a>, 
+            <a href="index.fr.html">français</a>, 
+            <a href="index.it.html">italiano</a>, 
+            <a href="index.nl.html">nederlands</a>, 
+            <a href="index.pt_BR.html">português</a>, 
+            <a href="index.ru.html">русский</a>, 
+            <br/>
+            <a href="index.ja.html">日本語</a>, 
+            <a href="index.zh.html">中文</a>, 
+            <a href="index.ko.html">한국어</a>
+            <br />
             por favor reporta cualquier problema en <a href="https://github.com/rogerdudler/git-guide/issues">github</a>
         </p>
         <img src="img/arrow.png" alt="" />

--- a/index.fr.html
+++ b/index.fr.html
@@ -32,8 +32,19 @@
         <p class="meta">
             par <a href="http://www.twitter.com/rogerdudler">Roger Dudler</a> (translation by <a href="https://github.com/KokaKiwi">KokaKiwi</a>)
             <br />Remerciements &agrave; <a href="http://www.twitter.com/tfnico">@tfnico</a>, <a href="http://www.twitter.com/fhd">@fhd</a>, <a href="http://www.namics.com">Namics</a><br />
-            this guide in <a href="index.de.html">deutsch</a>, <a href="index.html">english</a>, <a href="index.es.html">español</a>, <a href="index.it.html">italiano</a>, <a href="index.nl.html">nederlands</a>, <a href="index.pt_BR.html">português</a>, <a href="index.ru.html">русский</a>, <br/>
-            <a href="index.ja.html">日本語</a>, <a href="index.zh.html">中文</a>, <a href="index.ko.html">한국어</a><br />
+            this guide in 
+            <a href="index.html">english</a>,
+            <a href="index.de.html">deutsch</a>, 
+            <a href="index.es.html">español</a>, 
+            <a href="index.it.html">italiano</a>, 
+            <a href="index.nl.html">nederlands</a>, 
+            <a href="index.pt_BR.html">português</a>, 
+            <a href="index.ru.html">русский</a>, 
+            <br/>
+            <a href="index.ja.html">日本語</a>, 
+            <a href="index.zh.html">中文</a>, 
+            <a href="index.ko.html">한국어</a>
+            <br />
         </p>
         <img src="img/arrow.png" alt="" />
     </div>

--- a/index.html
+++ b/index.html
@@ -33,8 +33,19 @@
         <p class="meta">
             by <a href="http://www.twitter.com/rogerdudler">Roger Dudler</a>
             <br />credits to <a href="http://www.twitter.com/tfnico">@tfnico</a>, <a href="http://www.twitter.com/fhd">@fhd</a> and <a href="http://www.namics.com">Namics</a><br />
-            this guide in <a href="index.de.html">deutsch</a>, <a href="index.es.html">español</a>, <a href="index.fr.html">français</a>, <a href="index.it.html">italiano</a>, <a href="index.nl.html">nederlands</a>, <a href="index.pt_BR.html">português</a>, <a href="index.ru.html">русский</a>, <br/>
-            <a href="index.ja.html">日本語</a>, <a href="index.zh.html">中文</a>, <a href="index.ko.html">한국어</a><br />
+            this guide in 
+            <a href="index.de.html">deutsch</a>, 
+            <a href="index.es.html">español</a>, 
+            <a href="index.fr.html">français</a>, 
+            <a href="index.it.html">italiano</a>, 
+            <a href="index.nl.html">nederlands</a>, 
+            <a href="index.pt_BR.html">português</a>, 
+            <a href="index.ru.html">русский</a>, 
+            <br/>
+            <a href="index.ja.html">日本語</a>, 
+            <a href="index.zh.html">中文</a>, 
+            <a href="index.ko.html">한국어</a>
+            <br />
             please report issues on <a href="https://github.com/rogerdudler/git-guide/issues">github</a>
         </p>
         <img src="img/arrow.png" alt="" />

--- a/index.it.html
+++ b/index.it.html
@@ -32,8 +32,19 @@
         <p class="meta">
             by <a href="http://www.twitter.com/rogerdudler">Roger Dudler</a> (translation by <a href="http://www.twitter.com/stecb">@stecb</a>)
             <br />credits to <a href="http://www.twitter.com/tfnico">@tfnico</a>, <a href="http://www.twitter.com/fhd">@fhd</a>, <a href="http://www.namics.com">Namics</a><br />
-            this guide in <a href="index.de.html">deutsch</a>, <a href="index.html">english</a>, <a href="index.es.html">español</a>, <a href="index.fr.html">français</a>, <a href="index.nl.html">nederlands</a>, <a href="index.pt_BR.html">português</a>, <a href="index.ru.html">русский</a>, <br/>
-            <a href="index.ja.html">日本語</a>, <a href="index.zh.html">中文</a>, <a href="index.ko.html">한국어</a><br />
+            this guide in 
+            <a href="index.html">english</a>,
+            <a href="index.de.html">deutsch</a>, 
+            <a href="index.es.html">español</a>, 
+            <a href="index.fr.html">français</a>, 
+            <a href="index.nl.html">nederlands</a>, 
+            <a href="index.pt_BR.html">português</a>, 
+            <a href="index.ru.html">русский</a>, 
+            <br/>
+            <a href="index.ja.html">日本語</a>, 
+            <a href="index.zh.html">中文</a>, 
+            <a href="index.ko.html">한국어</a>
+            <br />
         </p>
         <img src="img/arrow.png" alt="" />
     </div>

--- a/index.ja.html
+++ b/index.ja.html
@@ -28,8 +28,19 @@
         <p class="meta">
             <a href="http://www.twitter.com/rogerdudler">Roger Dudler</a> (著) <a href="http://www.twitter.com/nacho4d">@nacho4d</a> (訳)
             <br />クレジット <a href="http://www.twitter.com/tfnico">@tfnico</a>, <a href="http://www.twitter.com/fhd">@fhd</a>, <a href="http://www.namics.com">Namics</a><br />
-            その他の言語 <a href="index.de.html">deutsch</a>, <a href="index.html">english</a>, <a href="index.fr.html">français</a>, <a href="index.it.html">italiano</a>, <a href="index.nl.html">nederlands</a>, <a href="index.pt_BR.html">português</a>, <a href="index.ru.html">русский</a>, <br/>
-            <a href="index.ja.html">日本語</a>, <a href="index.zh.html">中文</a>, <a href="index.ko.html">한국어</a><br />
+            その他の言語
+            <a href="index.html">english</a>,
+            <a href="index.de.html">deutsch</a>, 
+            <a href="index.es.html">español</a>, 
+            <a href="index.fr.html">français</a>, 
+            <a href="index.it.html">italiano</a>, 
+            <a href="index.nl.html">nederlands</a>, 
+            <a href="index.pt_BR.html">português</a>, 
+            <a href="index.ru.html">русский</a>, 
+            <br/>
+            <a href="index.zh.html">中文</a>, 
+            <a href="index.ko.html">한국어</a>
+            <br />
             問題などの報告は<a href="https://github.com/rogerdudler/git-guide/issues">github</a>でお願いします。
         </p>
         <img src="img/arrow.png" alt="" />

--- a/index.ko.html
+++ b/index.ko.html
@@ -33,8 +33,19 @@
         <p class="meta">
             만든이: <a href="http://www.twitter.com/rogerdudler">Roger Dudler</a><br />
             도와준 이들: <a href="http://www.twitter.com/tfnico">@tfnico</a>, <a href="http://www.twitter.com/fhd">@fhd</a>와 <a href="http://www.namics.com">Namics</a><br />
-            다른 언어로도 있어요: <a href="index.html">english</a>, <a href="index.de.html">deutsch</a>, <a href="index.es.html">español</a>, <a href="index.fr.html">français</a>, <a href="index.it.html">italiano</a>, <a href="index.nl.html">nederlands</a>,<br />
-            <a href="index.pt_BR.html">português</a>, <a href="index.ru.html">русский</a>, <a href="index.ja.html">日本語</a>, <a href="index.zh.html">中文</a><br/>
+            다른 언어로도 있어요: 
+            <a href="index.html">english</a>,
+            <a href="index.de.html">deutsch</a>, 
+            <a href="index.es.html">español</a>, 
+            <a href="index.fr.html">français</a>, 
+            <a href="index.it.html">italiano</a>, 
+            <a href="index.nl.html">nederlands</a>, 
+            <a href="index.pt_BR.html">português</a>, 
+            <a href="index.ru.html">русский</a>, 
+            <br/>
+            <a href="index.ja.html">日本語</a>, 
+            <a href="index.zh.html">中文</a>, 
+            <br />
             문제 보고는 <a href="https://github.com/rogerdudler/git-guide/issues">여기(github)</a>로!
         </p>
         <img src="img/arrow.png" alt="자, 갑시다!" />

--- a/index.nl.html
+++ b/index.nl.html
@@ -33,8 +33,19 @@
         <p class="meta">
             door <a href="http://www.twitter.com/rogerdudler">Roger Dudler</a> (vertaling door <a href="http://github.com/pierot">Pieter Michels</a>)
             <br />dank aan <a href="http://www.twitter.com/tfnico">@tfnico</a>, <a href="http://www.twitter.com/fhd">@fhd</a> en <a href="http://www.namics.com">Namics</a><br />
-            gids in <a href="index.de.html">deutsch</a>, <a href="index.html">english</a>, <a href="index.es.html">español</a>, <a href="index.fr.html">français</a>, <a href="index.it.html">italiano</a>, <a href="index.pt_BR.html">português</a>, <a href="index.ru.html">русский</a>, <br/>
-            <a href="index.ja.html">日本語</a>, <a href="index.zh.html">中文</a>, <a href="index.ko.html">한국어</a><br />
+            gids in 
+            <a href="index.html">english</a>,
+            <a href="index.de.html">deutsch</a>, 
+            <a href="index.es.html">español</a>, 
+            <a href="index.fr.html">français</a>, 
+            <a href="index.it.html">italiano</a>, 
+            <a href="index.pt_BR.html">português</a>, 
+            <a href="index.ru.html">русский</a>, 
+            <br/>
+            <a href="index.ja.html">日本語</a>, 
+            <a href="index.zh.html">中文</a>, 
+            <a href="index.ko.html">한국어</a>
+            <br />
             opmerkingen en aanpassingen op <a href="https://github.com/rogerdudler/git-guide/issues">github</a>
         </p>
         <img src="img/arrow.png" alt="" />

--- a/index.pt_BR.html
+++ b/index.pt_BR.html
@@ -33,8 +33,19 @@
         <p class="meta">
             por <a href="http://www.twitter.com/rogerdudler">Roger Dudler</a>
             <br />cr&eacute;ditos para <a href="http://www.twitter.com/tfnico">@tfnico</a>, <a href="http://www.twitter.com/fhd">@fhd</a> and <a href="http://www.namics.com">Namics</a><br />
-            guia em <a href="index.de.html">deutsch</a>, <a href="index.html">english</a>, <a href="index.es.html">español</a>, <a href="index.fr.html">français</a>, <a href="index.it.html">italiano</a>, <a href="index.nl.html">nederlands</a>, <a href="index.ru.html">русский</a>, <br/>
-            <a href="index.ja.html">日本語</a>, <a href="index.zh.html">中文</a>, <a href="index.ko.html">한국어</a><br />
+            guia em 
+            <a href="index.html">english</a>,
+            <a href="index.de.html">deutsch</a>, 
+            <a href="index.es.html">español</a>, 
+            <a href="index.fr.html">français</a>, 
+            <a href="index.it.html">italiano</a>, 
+            <a href="index.nl.html">nederlands</a>, 
+            <a href="index.ru.html">русский</a>, 
+            <br/>
+            <a href="index.ja.html">日本語</a>, 
+            <a href="index.zh.html">中文</a>, 
+            <a href="index.ko.html">한국어</a>
+            <br />
             por favor informe problemas em <a href="https://github.com/rogerdudler/git-guide/issues">github</a>
         </p>
         <img src="img/arrow.png" alt="" />

--- a/index.ru.html
+++ b/index.ru.html
@@ -33,8 +33,19 @@
         <p class="meta">
             <a href="http://www.twitter.com/rogerdudler">Роджер Дублер</a> (перевел <a href="http://dmitrywolf.com">Дмитрий Вольф</a>)
             <br />спасибо <a href="http://www.twitter.com/tfnico">@tfnico</a>, <a href="http://www.twitter.com/fhd">@fhd</a> and <a href="http://www.namics.com">Namics</a><br />
-            это руководство на <a href="index.de.html">deutsch</a>, <a href="index.html">english</a>, <a href="index.es.html">español</a>, <a href="index.fr.html">français</a>, <a href="index.it.html">italiano</a>, <a href="index.nl.html">nederlands</a>, <a href="index.pt_BR.html">português</a>, <br/>
-            <a href="index.ja.html">日本語</a>, <a href="index.zh.html">中文</a>, <a href="index.ko.html">한국어</a><br />
+            это руководство на 
+            <a href="index.html">english</a>,
+            <a href="index.de.html">deutsch</a>, 
+            <a href="index.es.html">español</a>, 
+            <a href="index.fr.html">français</a>, 
+            <a href="index.it.html">italiano</a>, 
+            <a href="index.nl.html">nederlands</a>, 
+            <a href="index.pt_BR.html">português</a>, 
+            <br/>
+            <a href="index.ja.html">日本語</a>, 
+            <a href="index.zh.html">中文</a>, 
+            <a href="index.ko.html">한국어</a>
+            <br />
             об ошибках сообщайте на <a href="https://github.com/rogerdudler/git-guide/issues">github</a>
         </p>
         <img src="img/arrow.png" alt="" />

--- a/index.zh.html
+++ b/index.zh.html
@@ -33,8 +33,19 @@
         <p class="meta">
             作者：<a href="http://www.twitter.com/rogerdudler">罗杰·杜德勒</a>
             <br />感谢：<a href="http://www.twitter.com/tfnico">@tfnico</a>, <a href="http://www.twitter.com/fhd">@fhd</a> and <a href="http://www.namics.com">Namics</a><br />
-            其他语言 <a href="index.html">English</a>、<a href="index.de.html">deutsch</a>、<a href="index.es.html">español</a>、<a href="index.fr.html">français</a>、<a href="index.it.html">italiano</a>、<a href="index.nl.html">nederlands</a>、<a href="index.pt_BR.html">português</a>、<a href="index.ru.html">русский</a>、<br/>
-            <a href="index.ja.html">日本語</a>, <a href="index.ko.html">한국어</a><br />
+            其他语言 
+            <a href="index.html">english</a>,
+            <a href="index.de.html">deutsch</a>, 
+            <a href="index.es.html">español</a>, 
+            <a href="index.fr.html">français</a>, 
+            <a href="index.it.html">italiano</a>, 
+            <a href="index.nl.html">nederlands</a>, 
+            <a href="index.pt_BR.html">português</a>, 
+            <a href="index.ru.html">русский</a>, 
+            <br/>
+            <a href="index.ja.html">日本語</a>, 
+            <a href="index.ko.html">한국어</a>
+            <br />
             如有纰漏，请到 <a href="https://github.com/rogerdudler/git-guide/issues">github</a> 填报
         </p>
         <img src="img/arrow.png" alt="" />


### PR DESCRIPTION
This will make merges somewhat easier since diff compares linewise.
It also makes the list of links easier to read and compare for humans.

Lines that are likely to have small differences between forks, might benefit from being split.
Lines that are likely to be equal or differ totally between forks, should not be split.
