### PR TITLE
use git vocabulary instead of svn or cvs

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
     </div>
     <a name="checkout"></a>
     <div class="scrollblock block-checkout">
-        <h2>checkout a repository</h2>
+        <h2>clone a repository</h2>
         <p>
             create a working copy of a local repository by running the command<br />
             <code>git clone /path/to/repository</code><br />


### PR DESCRIPTION
in git you clone a repository and checkout a branch. svn and cvs where the ones that used checkout for copying a repository.

Suggestion taken from hacker news https://news.ycombinator.com/item?id=7263135:

<blockquote> An improvement suggestion: do not use confusing terminology from other version control systems. Change "Checkout a repository" to "Clone an existing repository".

Using the word "checkout" might make sense if someone is coming from an svn/cvs background, but it's just confusing because checkout in git is a different command with a different meaning.

And besides, more and more people are being introduced to git without prior exposure to cvs or svn. E.g. in my university, CS freshmen submit their exercises using git. Many of them have no prior exposure to centralized version control or things to unlearn.</blockquote>
