### PR TITLE
Change the wording of "Checkout a Repository" to "Copy a Repository"

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -110,6 +110,8 @@ code {
 .block-create code { background-color: #000; color: #FFF; }
 .block-copy { background-color: #FFF; }
 .block-copy h2 { color: #000; }
+.block-checkout { background-color: #FFF; } /* .block-checkout can be dropped in the future, */
+.block-checkout h2 { color: #000; }         /* once all new languages use .block-copy */
 .block-trees { background-color: #4c0d09; }
 .block-trees h2 { color: #d3b2af; }
 .block-trees p { color: #d3b2af; }

--- a/css/style.css
+++ b/css/style.css
@@ -108,8 +108,8 @@ code {
 .block-create h2 { color: #FFF; }
 .block-create p { color: #FFF; }
 .block-create code { background-color: #000; color: #FFF; }
-.block-checkout { background-color: #FFF; }
-.block-checkout h2 { color: #000; }
+.block-copy { background-color: #FFF; }
+.block-copy h2 { color: #000; }
 .block-trees { background-color: #4c0d09; }
 .block-trees h2 { color: #d3b2af; }
 .block-trees p { color: #d3b2af; }

--- a/index.de.html
+++ b/index.de.html
@@ -80,9 +80,9 @@
             aus, um ein neues git-Repository anzulegen.
         </p>
     </div>
-    <a name="checkout"></a>
-    <div class="scrollblock block-checkout">
-        <h2>Ein Repository auschecken</h2>
+    <a name="copy"></a>
+    <div class="scrollblock block-copy">
+        <h2>Kopieren eines Repository</h2>
         <p>
             erstelle eine Arbeitskopie, indem du folgenden Befehl ausführst:<br>
             <code>git clone /pfad/zum/repository</code><br>

--- a/index.es.html
+++ b/index.es.html
@@ -75,9 +75,9 @@
             para crear un nuevo repositorio de git.
         </p>
     </div>
-    <a name="checkout"></a>
-    <div class="scrollblock block-checkout">
-        <h2>hacer checkout a un repositorio</h2>
+    <a name="copy"></a>
+    <div class="scrollblock block-copy">
+        <h2>copiar un repositorio</h2>
         <p>
             Crea una copia local del repositorio ejecutando<br />
             <code>git clone /path/to/repository</code><br />

--- a/index.fr.html
+++ b/index.fr.html
@@ -89,8 +89,8 @@
                 pour cr&eacute;er un nouveau d&eacute;p&ocirc;t.
             </p>
         </div>
-        <a name="checkout"></a>
-        <div class="scrollblock block-checkout">
+        <a name="copy"></a>
+        <div class="scrollblock block-copy">
             <h2>cloner un d&eacute;p&ocirc;t</h2>
             <p>
                 cr&eacute;ez une copie de votre d&eacute;p&ocirc;t local en ex&eacute;cutant la commande<br />

--- a/index.html
+++ b/index.html
@@ -81,9 +81,9 @@
             to create a new git repository.
         </p>
     </div>
-    <a name="checkout"></a>
-    <div class="scrollblock block-checkout">
-        <h2>checkout a repository</h2>
+    <a name="copy"></a>
+    <div class="scrollblock block-copy">
+        <h2>copy a repository</h2>
         <p>
             create a working copy of a local repository by running the command<br />
             <code>git clone /path/to/repository</code><br />

--- a/index.it.html
+++ b/index.it.html
@@ -78,9 +78,9 @@
             per creare un nuovo repository git.
         </p>
     </div>
-    <a name="checkout"></a>
-    <div class="scrollblock block-checkout">
-        <h2>checkout di un repository</h2>
+    <a name="copy"></a>
+    <div class="scrollblock block-copy">
+        <h2>copiare un repository</h2>
         <p>
             crea una copia di un repository locale eseguendo il comando<br />
             <code>git clone /percorso/del/repository</code><br />

--- a/index.ja.html
+++ b/index.ja.html
@@ -76,9 +76,9 @@
             を実行します。
         </p>
     </div>
-    <a name="checkout"></a>
-    <div class="scrollblock block-checkout">
-        <h2>リポジトリのチェックアウト</h2>
+    <a name="copy"></a>
+    <div class="scrollblock block-copy">
+        <h2>リポジトリのコピーを作成</h2>
         <p>
             ローカルのリポジトリをクローンするには<br />
             <code>git clone /path/to/repository</code><br />

--- a/index.ko.html
+++ b/index.ko.html
@@ -124,8 +124,8 @@
 				새로운 git 저장소가 만들어집니다.
 			</p>
 		</div>
-		<a name="checkout"></a>
-		<div class="scrollblock block-checkout">
+		<a name="copy"></a>
+		<div class="scrollblock block-copy">
 			<h2>저장소 받아오기</h2>
 			<p>
 				로컬 저장소를 복제(clone)하려면 아래 명령을 실행하세요.<br />

--- a/index.my.html
+++ b/index.my.html
@@ -99,9 +99,9 @@
             ဆိုပြီး git repository တစ်ခုကို စတင်ပါ။
         </p>
     </div>
-    <a name="checkout"></a>
-    <div class="scrollblock block-checkout">
-        <h2>repository ကို checkout လုပ်ခြင်း</h2>
+    <a name="copy"></a>
+    <div class="scrollblock block-copy">
+        <h2>repository ကို copy လုပ်ခြင်း</h2>
         <p>
         		copy အနေနဲ့ ပွားပြီးတော့ အလုပ်လုပ်မယ်ဆိုရင်တော့ အောက်က command ကို အသုံးပြုရပါတယ်။ <br/>
             <code>git clone /path/to/repository</code><br />

--- a/index.nl.html
+++ b/index.nl.html
@@ -80,9 +80,9 @@
             uit om een nieuwe repository aan te maken.
         </p>
     </div>
-    <a name="checkout"></a>
-    <div class="scrollblock block-checkout">
-        <h2>checkout a repository</h2>
+    <a name="copy"></a>
+    <div class="scrollblock block-copy">
+        <h2>copy a repository</h2>
         <p>
             haal een repository lokaal binnen<br />
             <code>git clone /path/to/repository</code><br />

--- a/index.pt_BR.html
+++ b/index.pt_BR.html
@@ -80,9 +80,9 @@
             para criar um novo reposit&oacute;rio.
         </p>
     </div>
-    <a name="checkout"></a>
-    <div class="scrollblock block-checkout">
-        <h2>obtenha um reposit&oacute;rio</h2>
+    <a name="copy"></a>
+    <div class="scrollblock block-copy">
+        <h2>copiar um reposit&oacute;rio</h2>
         <p>
             crie uma c&oacute;pia de trabalho em um reposit&oacute;rio local executando o comando<br />
             <code>git clone /caminho/para/o/reposit&oacute;rio</code><br />

--- a/index.ru.html
+++ b/index.ru.html
@@ -81,9 +81,9 @@
             
         </p>
     </div>
-    <a name="checkout"></a>
-    <div class="scrollblock block-checkout">
-        <h2>получение репозитория</h2>
+    <a name="copy"></a>
+    <div class="scrollblock block-copy">
+        <h2>копирования репозитория</h2>
         <p>
             Создать локальную рабочую копию репозитория можно командой<br />
             <code>git clone /путь/к/репозиторию</code><br />

--- a/index.tr.html
+++ b/index.tr.html
@@ -80,8 +80,8 @@
             komutunu çalıştırın.
         </p>
     </div>
-    <a name="checkout"></a>
-    <div class="scrollblock block-checkout">
+    <a name="copy"></a>
+    <div class="scrollblock block-copy">
         <h2>bir depoyu kopyalamak</h2>
         <p>
             yerel deponuzun çalışan bir kopyasını oluşturmak için<br />

--- a/index.vi.html
+++ b/index.vi.html
@@ -80,8 +80,8 @@
             <code>git init</code><br />
         </p>
     </div>
-    <a name="checkout"></a>
-    <div class="scrollblock block-checkout">
+    <a name="copy"></a>
+    <div class="scrollblock block-copy">
         <h2>sao chép (clone) một repository</h2>
         <p>
             để clone 1 repository có sẵn ở trên máy cục bộ, bạn hãy sử dụng dòng lệnh sau:<br />

--- a/index.zh.html
+++ b/index.zh.html
@@ -33,19 +33,19 @@
         <p class="meta">
             作者：<a href="http://www.twitter.com/rogerdudler">罗杰·杜德勒</a>
             <br />感谢：<a href="http://www.twitter.com/tfnico">@tfnico</a>, <a href="http://www.twitter.com/fhd">@fhd</a> 和 <a href="http://www.namics.com">Namics</a><br />
-            其他语言
+            其他语言 
             <a href="index.html">english</a>,
-            <a href="index.de.html">deutsch</a>,
-            <a href="index.es.html">español</a>,
-            <a href="index.fr.html">français</a>,
-            <a href="index.it.html">italiano</a>,
-            <a href="index.nl.html">nederlands</a>,
-            <a href="index.pt_BR.html">português</a>,
+            <a href="index.de.html">deutsch</a>, 
+            <a href="index.es.html">español</a>, 
+            <a href="index.fr.html">français</a>, 
+            <a href="index.it.html">italiano</a>, 
+            <a href="index.nl.html">nederlands</a>, 
+            <a href="index.pt_BR.html">português</a>, 
             <a href="index.ru.html">русский</a>,
             <a href="index.tr.html">türkçe</a>,
             <br/>
             <a href="index.my.html">မြန်မာ</a>,
-            <a href="index.ja.html">日本語</a>,
+            <a href="index.ja.html">日本語</a>, 
             <a href="index.ko.html">한국어</a>
             <a href="index.vi.html">Vietnamese</a>
             <br />

--- a/index.zh.html
+++ b/index.zh.html
@@ -33,19 +33,19 @@
         <p class="meta">
             作者：<a href="http://www.twitter.com/rogerdudler">罗杰·杜德勒</a>
             <br />感谢：<a href="http://www.twitter.com/tfnico">@tfnico</a>, <a href="http://www.twitter.com/fhd">@fhd</a> 和 <a href="http://www.namics.com">Namics</a><br />
-            其他语言 
+            其他语言
             <a href="index.html">english</a>,
-            <a href="index.de.html">deutsch</a>, 
-            <a href="index.es.html">español</a>, 
-            <a href="index.fr.html">français</a>, 
-            <a href="index.it.html">italiano</a>, 
-            <a href="index.nl.html">nederlands</a>, 
-            <a href="index.pt_BR.html">português</a>, 
+            <a href="index.de.html">deutsch</a>,
+            <a href="index.es.html">español</a>,
+            <a href="index.fr.html">français</a>,
+            <a href="index.it.html">italiano</a>,
+            <a href="index.nl.html">nederlands</a>,
+            <a href="index.pt_BR.html">português</a>,
             <a href="index.ru.html">русский</a>,
             <a href="index.tr.html">türkçe</a>,
             <br/>
             <a href="index.my.html">မြန်မာ</a>,
-            <a href="index.ja.html">日本語</a>, 
+            <a href="index.ja.html">日本語</a>,
             <a href="index.ko.html">한국어</a>
             <a href="index.vi.html">Vietnamese</a>
             <br />
@@ -81,8 +81,8 @@
             以创建新的 git 仓库。
         </p>
     </div>
-    <a name="checkout"></a>
-    <div class="scrollblock block-checkout">
+    <a name="copy"></a>
+    <div class="scrollblock block-copy">
         <h2>检出仓库</h2>
         <p>
             执行如下命令以创建一个本地仓库的克隆版本：<br />


### PR DESCRIPTION
**"Checkout a Repository"** might lead to some confusion for people learning git, since `git checkout` is an actual thing and is totally different from `git clone`. I've changed the wording to: **"Copy a Repository"**

I've made the appropriate changes to all index.XX.html (including renaming of an anchor and a class). There were three that already used 'copy' instead of 'checkout' and two (Korean & Chinese) that I didn't know how to translate.

I also fixed the css file, since `block-checkout` class was renamed to `block-copy`.
