### PR TITLE
Fix dead link.

### DIFF
--- a/index.de.html
+++ b/index.de.html
@@ -68,7 +68,7 @@
             <a href="http://msysgit.github.io/">git für Windows herunterladen</a>
         </p>
         <p>
-            <a href="http://book.git-scm.com/2_installing_git.html">git für Linux herunterladen</a>
+            <a href="http://git-scm.com/download/linux/">git für Linux herunterladen</a>
         </p>
     </div>
     <a name="create"></a>

--- a/index.es.html
+++ b/index.es.html
@@ -63,7 +63,7 @@
             <a href="http://msysgit.github.io/">Descarga git para Windows</a>
         </p>
         <p>
-            <a href="http://book.git-scm.com/2_installing_git.html">Descarga git para Linux</a>
+            <a href="http://git-scm.com/download/linux/">Descarga git para Linux</a>
         </p>
     </div>
     <a name="create"></a>

--- a/index.fr.html
+++ b/index.fr.html
@@ -77,7 +77,7 @@
                 <a href="http://msysgit.github.io/">T&eacute;l&eacute;charger git pour Windows</a>
             </p>
             <p>
-                <a href="http://book.git-scm.com/2_installing_git.html">T&eacute;l&eacute;charger git pour Linux</a>
+                <a href="http://git-scm.com/download/linux/">T&eacute;l&eacute;charger git pour Linux</a>
             </p>
         </div>
         <a name="create"></a>

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
             <a href="http://msysgit.github.io/">Download git for Windows</a>
         </p>
         <p>
-            <a href="http://book.git-scm.com/2_installing_git.html">Download git for Linux</a>
+            <a href="http://git-scm.com/download/linux/">Download git for Linux</a>
         </p>
     </div>
     <a name="create"></a>

--- a/index.it.html
+++ b/index.it.html
@@ -66,7 +66,7 @@
             <a href="http://msysgit.github.io/">Scarica git per Windows</a>
         </p>
         <p>
-            <a href="http://book.git-scm.com/2_installing_git.html">Scarica git for Linux</a>
+            <a href="http://git-scm.com/download/linux/">Scarica git for Linux</a>
         </p>
     </div>
     <a name="create"></a>

--- a/index.ja.html
+++ b/index.ja.html
@@ -63,7 +63,7 @@
             <a href="http://msysgit.github.io/">Windows用 Gitをダウンロード</a>
         </p>
         <p>
-            <a href="http://book.git-scm.com/2_installing_git.html">Linux用 Gitをダウンロード</a>
+            <a href="http://git-scm.com/download/linux/">Linux用 Gitをダウンロード</a>
         </p>
     </div>
     <a name="create"></a>

--- a/index.ko.html
+++ b/index.ko.html
@@ -113,7 +113,7 @@
 			<h2>설치</h2>
 		        <p><a href="http://code.google.com/p/git-osx-installer/downloads/list?can=3">OS X용 git 다운로드</a></p>
 		        <p><a href="http://msysgit.github.io/">Windows용 git 다운로드</a></p>
-			<p><a href="http://book.git-scm.com/2_installing_git.html">Linux용 git 다운로드</a></p>
+			<p><a href="http://git-scm.com/download/linux/">Linux용 git 다운로드</a></p>
 		</div>
 		<a name="create"></a>
 		<div class="scrollblock block-create">

--- a/index.my.html
+++ b/index.my.html
@@ -86,7 +86,7 @@
             <a href="http://msysgit.github.io/">Windows အတွက် git Download</a>
         </p>
         <p>
-            <a href="http://book.git-scm.com/2_installing_git.html">Linux အတွက် git Download</a>
+            <a href="http://git-scm.com/download/linux/">Linux အတွက် git Download</a>
         </p>
     </div>
     <a name="create"></a>

--- a/index.nl.html
+++ b/index.nl.html
@@ -68,7 +68,7 @@
             <a href="http://msysgit.github.io/">Download git voor Windows</a>
         </p>
         <p>
-            <a href="http://book.git-scm.com/2_installing_git.html">Download git voor Linux</a>
+            <a href="http://git-scm.com/download/linux/">Download git voor Linux</a>
         </p>
     </div>
     <a name="create"></a>

--- a/index.pt_BR.html
+++ b/index.pt_BR.html
@@ -68,7 +68,7 @@
             <a href="http://msysgit.github.io/">Baixe o git para Windows</a>
         </p>
         <p>
-            <a href="http://book.git-scm.com/2_installing_git.html">Baixe o git para Linux</a>
+            <a href="http://git-scm.com/download/linux/">Baixe o git para Linux</a>
         </p>
     </div>
     <a name="create"></a>

--- a/index.ru.html
+++ b/index.ru.html
@@ -68,7 +68,7 @@
             <a href="http://msysgit.github.io/">Скачать git для Windows</a>
         </p>
         <p>
-            <a href="http://book.git-scm.com/2_installing_git.html">Скачать git для Linux</a>
+            <a href="http://git-scm.com/download/linux/">Скачать git для Linux</a>
         </p>
     </div>
     <a name="create"></a>

--- a/index.tr.html
+++ b/index.tr.html
@@ -68,7 +68,7 @@
             <a href="http://msysgit.github.io/">Windows için git'i İndir</a>
         </p>
         <p>
-            <a href="http://book.git-scm.com/2_installing_git.html">Linux için git'i İndir</a>
+            <a href="http://git-scm.com/download/linux/">Linux için git'i İndir</a>
         </p>
     </div>
     <a name="create"></a>

--- a/index.vi.html
+++ b/index.vi.html
@@ -69,7 +69,7 @@
             <a href="http://msysgit.github.io/">Tải git về cho Windows</a>
         </p>
         <p>
-            <a href="http://book.git-scm.com/2_installing_git.html">Tải git về cho Linux</a>
+            <a href="http://git-scm.com/download/linux/">Tải git về cho Linux</a>
         </p>
     </div>
     <a name="create"></a>

--- a/index.zh.html
+++ b/index.zh.html
@@ -69,7 +69,7 @@
             <a href="http://msysgit.github.io/">下载 git Windows 版</a>
         </p>
         <p>
-            <a href="http://book.git-scm.com/2_installing_git.html">下载 git Linux 版</a>
+            <a href="http://git-scm.com/download/linux/">下载 git Linux 版</a>
         </p>
     </div>
     <a name="create"></a>


### PR DESCRIPTION
Fix link for "Download git for Linux".

Dead link: http://git-scm.com/book/en%2FGetting-Started-Installing-Git
New link: http://git-scm.com/download/linux

![scrot](https://cloud.githubusercontent.com/assets/4251257/4586646/a8148c2e-501b-11e4-8807-26c787086451.png)
