### PR TITLE
Fix download link for OSX for existing translations

### DIFF
--- a/index.de.html
+++ b/index.de.html
@@ -64,7 +64,7 @@
     <div class="scrollblock block-setup">
         <h2>Installation</h2>
         <p>
-            <a href="http://code.google.com/p/git-osx-installer/downloads/list?can=3">git für OS X herunterladen</a>
+            <a href="http://git-scm.com/download/mac">git für OS X herunterladen</a>
         </p>
         <p>
             <a href="http://msysgit.github.io/">git für Windows herunterladen</a>

--- a/index.es.html
+++ b/index.es.html
@@ -59,7 +59,7 @@
     <div class="scrollblock block-setup">
         <h2>configuración</h2>
         <p>
-            <a href="http://code.google.com/p/git-osx-installer/downloads/list?can=3">Descarga git para OSX</a>
+            <a href="http://git-scm.com/download/mac">Descarga git para OSX</a>
         </p>
         <p>
             <a href="http://msysgit.github.io/">Descarga git para Windows</a>

--- a/index.fr.html
+++ b/index.fr.html
@@ -73,7 +73,7 @@
         <div class="scrollblock block-setup">
             <h2>installation</h2>
             <p>
-                <a href="http://code.google.com/p/git-osx-installer/downloads/list?can=3">T&eacute;l&eacute;charger git pour Mac OSX</a>
+                <a href="http://git-scm.com/download/mac">T&eacute;l&eacute;charger git pour Mac OSX</a>
             </p>
             <p>
                 <a href="http://msysgit.github.io/">T&eacute;l&eacute;charger git pour Windows</a>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
     <div class="scrollblock block-setup">
         <h2>setup</h2>
         <p>
-            <a href="http://code.google.com/p/git-osx-installer/downloads/list?can=3">Download git for OSX</a>
+            <a href="http://git-scm.com/download/mac">Download git for OSX</a>
         </p>
         <p>
             <a href="http://msysgit.github.io/">Download git for Windows</a>

--- a/index.id.html
+++ b/index.id.html
@@ -64,7 +64,7 @@
     <div class="scrollblock block-setup">
         <h2>persiapan</h2>
         <p>
-            <a href="http://code.google.com/p/git-osx-installer/downloads/list?can=3">Unduh git untuk OSX</a>
+            <a href="http://git-scm.com/download/mac">Unduh git untuk OSX</a>
         </p>
         <p>
             <a href="http://msysgit.github.io/">Unduh git untuk Windows</a>

--- a/index.it.html
+++ b/index.it.html
@@ -62,7 +62,7 @@
     <div class="scrollblock block-setup">
         <h2>installazione</h2>
         <p>
-            <a href="http://code.google.com/p/git-osx-installer/downloads/list?can=3">Scarica git per OSX</a>
+            <a href="http://git-scm.com/download/mac">Scarica git per OSX</a>
         </p>
         <p>
             <a href="http://msysgit.github.io/">Scarica git per Windows</a>

--- a/index.ja.html
+++ b/index.ja.html
@@ -59,7 +59,7 @@
     <div class="scrollblock block-setup">
         <h2>設定</h2>
         <p>
-            <a href="http://code.google.com/p/git-osx-installer/downloads/list?can=3">OSX用 Gitをダウンロード</a>
+            <a href="http://git-scm.com/download/mac">OSX用 Gitをダウンロード</a>
         </p>
         <p>
             <a href="http://msysgit.github.io/">Windows用 Gitをダウンロード</a>

--- a/index.ko.html
+++ b/index.ko.html
@@ -114,7 +114,7 @@
 		<a name="setup"></a>
 		<div class="scrollblock block-setup">
 			<h2>설치</h2>
-		        <p><a href="http://code.google.com/p/git-osx-installer/downloads/list?can=3">OS X용 git 다운로드</a></p>
+		        <p><a href="http://git-scm.com/download/mac">OS X용 git 다운로드</a></p>
 		        <p><a href="http://msysgit.github.io/">Windows용 git 다운로드</a></p>
 			<p><a href="http://book.git-scm.com/2_installing_git.html">Linux용 git 다운로드</a></p>
 		</div>

--- a/index.my.html
+++ b/index.my.html
@@ -82,7 +82,7 @@
     <div class="scrollblock block-setup">
         <h2>ပြင်ဆင်ခြင်း</h2>
         <p>
-            <a href="http://code.google.com/p/git-osx-installer/downloads/list?can=3">OSX အတွက် git Download</a>
+            <a href="http://git-scm.com/download/mac">OSX အတွက် git Download</a>
         </p>
         <p>
             <a href="http://msysgit.github.io/">Windows အတွက် git Download</a>

--- a/index.nl.html
+++ b/index.nl.html
@@ -64,7 +64,7 @@
     <div class="scrollblock block-setup">
         <h2>setup</h2>
         <p>
-            <a href="http://code.google.com/p/git-osx-installer/downloads/list?can=3">Download git voor OSX</a>
+            <a href="http://git-scm.com/download/mac">Download git voor OSX</a>
         </p>
         <p>
             <a href="http://msysgit.github.io/">Download git voor Windows</a>

--- a/index.pl.html
+++ b/index.pl.html
@@ -64,7 +64,7 @@
         <h2>Instalacja</h2>
         <p>
             <a
-                href="http://code.google.com/p/git-osx-installer/downloads/list?can=3">Pobierz
+                href="http://git-scm.com/download/mac">Pobierz
             git dla OSX</a>
         </p>
         <p>

--- a/index.pt_BR.html
+++ b/index.pt_BR.html
@@ -64,7 +64,7 @@
     <div class="scrollblock block-setup">
         <h2>instala&ccedil;&atilde;o</h2>
         <p>
-            <a href="http://code.google.com/p/git-osx-installer/downloads/list?can=3">Baixe o git para OSX</a>
+            <a href="http://git-scm.com/download/mac">Baixe o git para OSX</a>
         </p>
         <p>
             <a href="http://msysgit.github.io/">Baixe o git para Windows</a>

--- a/index.ru.html
+++ b/index.ru.html
@@ -64,7 +64,7 @@
     <div class="scrollblock block-setup">
         <h2>установка</h2>
         <p>
-            <a href="http://code.google.com/p/git-osx-installer/downloads/list?can=3">Скачать git для OSX</a>
+            <a href="http://git-scm.com/download/mac">Скачать git для OSX</a>
         </p>
         <p>
             <a href="http://msysgit.github.io/">Скачать git для Windows</a>

--- a/index.tr.html
+++ b/index.tr.html
@@ -64,7 +64,7 @@
     <div class="scrollblock block-setup">
         <h2>kurulum</h2>
         <p>
-            <a href="http://code.google.com/p/git-osx-installer/downloads/list?can=3">OSX için git'i İndir</a>
+            <a href="http://git-scm.com/download/mac">OSX için git'i İndir</a>
         </p>
         <p>
             <a href="http://msysgit.github.io/">Windows için git'i İndir</a>

--- a/index.vi.html
+++ b/index.vi.html
@@ -65,7 +65,7 @@
     <div class="scrollblock block-setup">
         <h2>cài đặt</h2>
         <p>
-            <a href="http://code.google.com/p/git-osx-installer/downloads/list?can=3">Tải git về cho OSX</a>
+            <a href="http://git-scm.com/download/mac">Tải git về cho OSX</a>
         </p>
         <p>
             <a href="http://msysgit.github.io/">Tải git về cho Windows</a>

--- a/index.zh.html
+++ b/index.zh.html
@@ -65,7 +65,7 @@
     <div class="scrollblock block-setup">
         <h2>安装</h2>
         <p>
-            <a href="http://code.google.com/p/git-osx-installer/downloads/list?can=3">下载 git OSX 版</a>
+            <a href="http://git-scm.com/download/mac">下载 git OSX 版</a>
         </p>
         <p>
             <a href="http://msysgit.github.io/">下载 git Windows 版</a>


### PR DESCRIPTION
The existing download link for Mac OS X is obsolete. Currently the link gives an obsolete version. This link will stop working when Google Code shuts down in 2016, which may be an improvement over giving an obsolete version.
