### PR TITLE
Updated the graphical clients list

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,10 +223,12 @@
         <p>
             <ul>
                 <li><a href="http://gitx.laullon.com/">GitX (L) (OSX, open source)</a></li>
-                <li><a href="http://www.git-tower.com/">Tower (OSX)</a></li>
-                <li><a href="http://www.sourcetreeapp.com/">Source Tree (OSX & Windows, free)</a></li>
-                <li><a href="http://mac.github.com/">GitHub for Mac (OSX, free)</a></li>
+                <li><a href="http://www.git-tower.com/">Tower (OSX &amp; Windows)</a></li>
+                <li><a href="http://www.sourcetreeapp.com/">Source Tree (OSX &amp; Windows, free)</a></li>
+                <li><a href="http://desktop.github.com/">GitHub Desktop (OSX &amp; Windows, free)</a></li>
                 <li><a href="https://itunes.apple.com/gb/app/gitbox/id403388357?mt=12">GitBox (OSX, App Store)</a></li>
+                <li><a href="https://www.gitkraken.com/">GitKraken (OSX, Windows &amp; Linux, free)</li>
+                <li><a href="https://tortoisegit.org/">TortoiseGit (Windows, free)</a>
             </ul>
         </p>
         <h3>guides</h3>


### PR DESCRIPTION
Updated the graphical clients list to include:

- Tower for Windows (#145)
- GitHub Desktop (#59) (rebrand of GitHub for Mac, also available for Windows)
- GitKraken
- TortoiseGit