### PR TITLE
Replace non working progit.org domain with correct location for Progit book

### DIFF
--- a/index.de.html
+++ b/index.de.html
@@ -214,7 +214,7 @@
         <p>
             <ul>
                 <li><a href="http://book.git-scm.com/">Git Community Book</a></li>
-                <li><a href="http://progit.org/book/">Pro Git</a></li>
+                <li><a href="https://git-scm.com/book/">Pro Git</a></li>
                 <li><a href="http://think-like-a-git.net/">Think like a git</a></li>
                 <li><a href="http://help.github.com/">GitHub Help</a></li>
                 <li><a href="http://marklodato.github.com/visual-git-guide/index-en.html">A Visual Git Guide</a></li>

--- a/index.es.html
+++ b/index.es.html
@@ -211,7 +211,7 @@
         <p>
             <ul>
                 <li><a href="http://book.git-scm.com/">Git Community Book</a></li>
-                <li><a href="http://progit.org/book/">Pro Git</a></li>
+                <li><a href="https://git-scm.com/book/">Pro Git</a></li>
                 <li><a href="http://think-like-a-git.net/">Think like a git</a></li>
                 <li><a href="http://help.github.com/">GitHub Help</a></li>
                 <li><a href="http://marklodato.github.com/visual-git-guide/index-en.html">A Visual Git Guide</a></li>

--- a/index.fr.html
+++ b/index.fr.html
@@ -227,7 +227,7 @@
         <p>
             <ul>
                 <li><a href="http://book.git-scm.com/">Git Community Book</a></li>
-                <li><a href="http://progit.org/book/">Pro Git</a></li>
+                <li><a href="https://git-scm.com/book/">Pro Git</a></li>
                 <li><a href="http://think-like-a-git.net/">Think like a git</a></li>
                 <li><a href="http://help.github.com/">GitHub Help</a></li>
                 <li><a href="http://marklodato.github.com/visual-git-guide/index-en.html">A Visual Git Guide</a></li>

--- a/index.html
+++ b/index.html
@@ -233,7 +233,7 @@
         <p>
             <ul>
                 <li><a href="http://book.git-scm.com/">Git Community Book</a></li>
-                <li><a href="http://progit.org/book/">Pro Git</a></li>
+                <li><a href="https://git-scm.com/book/">Pro Git</a></li>
                 <li><a href="http://think-like-a-git.net/">Think like a git</a></li>
                 <li><a href="http://help.github.com/">GitHub Help</a></li>
                 <li><a href="http://marklodato.github.com/visual-git-guide/index-en.html">A Visual Git Guide</a></li>

--- a/index.id.html
+++ b/index.id.html
@@ -231,7 +231,7 @@
         <p>
             <ul>
                 <li><a href="http://git-scm.com/book/id">Buku Komunitas Git</a></li>
-                <li><a href="http://progit.org/book/">Git Pro</a></li>
+                <li><a href="https://git-scm.com/book/">Git Pro</a></li>
                 <li><a href="http://think-like-a-git.net/">Berfikir seperti git</a></li>
                 <li><a href="http://help.github.com/">Bantuan GitHub</a></li>
                 <li><a href="http://marklodato.github.com/visual-git-guide/index-en.html">Panduan Git Visual</a></li>

--- a/index.it.html
+++ b/index.it.html
@@ -213,7 +213,7 @@
         <p>
             <ul>
                 <li><a href="http://book.git-scm.com/">Git Community Book</a></li>
-                <li><a href="http://progit.org/book/">Pro Git</a></li>
+                <li><a href="https://git-scm.com/book/">Pro Git</a></li>
                 <li><a href="http://think-like-a-git.net/">Think like a git</a></li>
                 <li><a href="http://help.github.com/">GitHub Help</a></li>
                 <li><a href="http://marklodato.github.com/visual-git-guide/index-en.html">A Visual Git Guide</a></li>

--- a/index.ja.html
+++ b/index.ja.html
@@ -216,8 +216,8 @@
         <p>
             <ul>
                 <li><a href="http://book.git-scm.com/">Git Community Book</a></li>
-                <li><a href="http://progit.org/book/">Pro Git</a></li>
-                <li><a href="http://progit.org/book/ja/">Pro Git(日本語)</a></li>
+                <li><a href="https://git-scm.com/book/">Pro Git</a></li>
+                <li><a href="https://git-scm.com/book/ja/">Pro Git(日本語)</a></li>
                 <li><a href="http://think-like-a-git.net/">Think like a git</a></li>
                 <li><a href="http://help.github.com/">GitHub Help</a></li>
                 <li><a href="http://marklodato.github.com/visual-git-guide/index-en.html">A Visual Git Guide</a></li>

--- a/index.my.html
+++ b/index.my.html
@@ -257,7 +257,7 @@
         <p>
             <ul>
                 <li><a href="http://book.git-scm.com/">Git Community Book</a></li>
-                <li><a href="http://progit.org/book/">Pro Git</a></li>
+                <li><a href="https://git-scm.com/book/">Pro Git</a></li>
                 <li><a href="http://think-like-a-git.net/">Think like a git</a></li>
                 <li><a href="http://help.github.com/">GitHub Help</a></li>
                 <li><a href="http://marklodato.github.com/visual-git-guide/index-en.html">A Visual Git Guide</a></li>

--- a/index.nl.html
+++ b/index.nl.html
@@ -230,7 +230,7 @@
         <p>
             <ul>
                 <li><a href="http://book.git-scm.com/">Git Community Book</a></li>
-                <li><a href="http://progit.org/book/">Pro Git</a></li>
+                <li><a href="https://git-scm.com/book/">Pro Git</a></li>
                 <li><a href="http://think-like-a-git.net/">Think like a git</a></li>
                 <li><a href="http://help.github.com/">GitHub Help</a></li>
                 <li><a href="http://marklodato.github.com/visual-git-guide/index-en.html">A Visual Git Guide</a></li>

--- a/index.pl.html
+++ b/index.pl.html
@@ -266,7 +266,7 @@
         <p>
             <ul>
                 <li><a href="http://book.git-scm.com/">Git Community Book</a></li>
-                <li><a href="http://progit.org/book/">Pro Git</a></li>
+                <li><a href="https://git-scm.com/book/">Pro Git</a></li>
                 <li><a href="http://think-like-a-git.net/">Think like a git</a></li>
                 <li><a href="http://help.github.com/">GitHub Help</a></li>
                 <li><a href="http://marklodato.github.com/visual-git-guide/index-en.html">A Visual Git Guide</a></li>

--- a/index.pt_BR.html
+++ b/index.pt_BR.html
@@ -215,7 +215,7 @@
         <p>
             <ul>
                 <li><a href="http://git-scm.com/book/pt-br/">Livro da comunidade Git</a></li>
-                <li><a href="http://progit.org/book/">Pro Git</a></li>
+                <li><a href="https://git-scm.com/book/">Pro Git</a></li>
                 <li><a href="http://think-like-a-git.net/">Pense como um git</a></li>
                 <li><a href="http://help.github.com/">Ajuda do GitHub</a></li>
                 <li><a href="http://marklodato.github.com/visual-git-guide/index-en.html">Um guia visual do Git</a></li>

--- a/index.ru.html
+++ b/index.ru.html
@@ -218,7 +218,7 @@
         <p>
             <ul>
                 <li><a href="http://book.git-scm.com/">Git Community Book</a></li>
-                <li><a href="http://progit.org/book/ru/">Pro Git (перевод)</a></li>
+                <li><a href="https://git-scm.com/book/ru/">Pro Git (перевод)</a></li>
                 <li><a href="http://think-like-a-git.net/">Think like a git</a></li>
                 <li><a href="http://help.github.com/">GitHub Help</a></li>
                 <li><a href="http://marklodato.github.com/visual-git-guide/index-en.html">A Visual Git Guide</a></li>

--- a/index.tr.html
+++ b/index.tr.html
@@ -217,7 +217,7 @@
         <p>
             <ul>
                 <li><a href="http://book.git-scm.com/">Git Community Book</a></li>
-                <li><a href="http://progit.org/book/">Pro Git</a></li>
+                <li><a href="https://git-scm.com/book/">Pro Git</a></li>
                 <li><a href="http://think-like-a-git.net/">Think like a git</a></li>
                 <li><a href="http://help.github.com/">GitHub Help</a></li>
                 <li><a href="http://marklodato.github.com/visual-git-guide/index-en.html">A Visual Git Guide</a></li>

--- a/index.vi.html
+++ b/index.vi.html
@@ -215,7 +215,7 @@
         <p>
             <ul>
                 <li><a href="http://book.git-scm.com/">Git Community Book</a></li>
-                <li><a href="http://progit.org/book/">Pro Git</a></li>
+                <li><a href="https://git-scm.com/book/">Pro Git</a></li>
                 <li><a href="http://think-like-a-git.net/">Think like a git</a></li>
                 <li><a href="http://help.github.com/">GitHub Help</a></li>
                 <li><a href="http://marklodato.github.com/visual-git-guide/index-en.html">A Visual Git Guide</a></li>

--- a/index.zh.html
+++ b/index.zh.html
@@ -230,7 +230,7 @@
         <p>
             <ul>
                 <li><a href="http://book.git-scm.com/">Git 社区参考书</a></li>
-                <li><a href="http://progit.org/book/">专业 Git</a></li>
+                <li><a href="https://git-scm.com/book/">专业 Git</a></li>
                 <li><a href="http://think-like-a-git.net/">像 git 那样思考</a></li>
                 <li><a href="http://help.github.com/">GitHub 帮助</a></li>
                 <li><a href="http://marklodato.github.io/visual-git-guide/index-zh-cn.html">图解 Git</a></li>


### PR DESCRIPTION
Hello, this patch fixes non working links for the Pro git book. Some translations are already available so they were added to those links also.

Thanks for considering merging or checking this out.

Kind regards, Peter.